### PR TITLE
Add the internal Route 53 CNAME record value as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ Full working references are available at [examples](examples)
 | Name | Description |
 |------|-------------|
 | elasticache_endpoint | Elasticache endpoint address |
+| elasticache_internal_r53_record | Internal Route 53 record FQDN for the Elasticache endpoint(s) |

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -88,12 +88,27 @@ output "memcached_endpoint" {
   value       = "${module.elasticache_memcached.elasticache_endpoint}"
 }
 
+output "memcached_internal_r53_record" {
+  description = "Internal Route 53 record FQDN for the Elasticache endpoint(s)"
+  value       = "${module.elasticache_memcached.elasticache_internal_r53_record}"
+}
+
 output "redis_endpoint" {
   description = "Redis endpoint"
   value       = "${module.elasticache_redis.elasticache_endpoint}"
 }
 
+output "redis_internal_r53_record" {
+  description = "Internal Route 53 record FQDN for the Elasticache endpoint(s)"
+  value       = "${module.elasticache_redis.elasticache_internal_r53_record}"
+}
+
 output "redis_multi_shard_endpoint" {
   description = "Redis Multi Shard endpoint"
   value       = "${module.elasticache_redis_multi_shard.elasticache_endpoint}"
+}
+
+output "redis_multi_shard_internal_r53_record" {
+  description = "Internal Route 53 record FQDN for the Elasticache endpoint(s)"
+  value       = "${module.elasticache_redis_multi_shard.elasticache_internal_r53_record}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "elasticache_endpoint" {
   description = "Elasticache endpoint address"
   value       = "${element(coalescelist(aws_elasticache_replication_group.redis_rep_group.*.primary_endpoint_address, aws_elasticache_replication_group.redis_multi_shard_rep_group.*.configuration_endpoint_address, aws_elasticache_cluster.cache_cluster.*.configuration_endpoint, list("novalue")),0)}"
 }
+
+output "elasticache_internal_r53_record" {
+  description = "Internal Route 53 record FQDN for the Elasticache endpoint(s)"
+  value       = "${aws_route53_record.internal_record_set_elasticache.*.fqdn}"
+}


### PR DESCRIPTION
This will output the internal route53 CNAME value if one was created as part of the building of the Elasticache cluster.