### PR TITLE
Fix constructed cluster name length

### DIFF
--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -112,6 +112,28 @@ module "elasticache_redis_2" {
   }
 }
 
+module "elasticache_redis_constructed_cluster_name_20_chars" {
+  source                  = "../../module"
+  cluster_name            = "this-is-twenty-chars"
+  cluster_name_version    = "this-is-twenty-chars"
+  elasticache_engine_type = "redis40"
+  instance_class          = "cache.t2.medium"
+  redis_multi_shard       = false
+  subnets                 = ["${module.vpc.private_subnets}"]
+  security_group_list     = ["${module.security_groups.elastic_cache_redis_security_group_id}"]
+}
+
+module "elasticache_redis_constructed_cluster_name_19_chars" {
+  source                  = "../../module"
+  cluster_name            = "this-is-only-19-ok"
+  cluster_name_version    = "this-is-only-19-ok"
+  elasticache_engine_type = "redis40"
+  instance_class          = "cache.t2.medium"
+  redis_multi_shard       = false
+  subnets                 = ["${module.vpc.private_subnets}"]
+  security_group_list     = ["${module.security_groups.elastic_cache_redis_security_group_id}"]
+}
+
 output "memcached_endpoint" {
   description = "Elasticache endpoint"
   value       = "${module.elasticache_memcached.elasticache_endpoint}"


### PR DESCRIPTION
Full details are in the commit comment, which are copied below. We caught this when accidentally setting the `cluster_name_version` parameter to an automatically generated 20 character string and happened to notice that 19 characters resulted in strange behavior as well.

---

Issues were presenting themselves when both the `cluster_name` and `cluster_name_version` were _both_ 19 or 20 characters in length.

If they were both 19 characters in length, `substring_length` would evaluate to `0`, meaning that the `substr(var.cluster_name, 0, local.substring_length))` expression for `constructed_cluster_name` would evaluate to `""` and end up making the `"-"` the first character of the `constructed_cluster_name`, which is invalid.

If they were both 20 characters in length, the `substring_length` value would evaluate to `-1`, which makes all `substr(...)` expressions using it as the length parameter actually extract _all_ of the string.

This solution will:
1. Use a `replace(...)` call on the first component of the `join("-", list(...))` expression to remove the leading `-` if present.
2. Limit the overall length of the `constructed_cluster_name`, post-construction, to a maximum of 20 characters.
3. Use `truncated_constructed_cluster_name` to avoid having to apply the truncation on every usage.
