### PR TITLE
Update pinning to allow for new aws provider versions

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.2, < 1.41.0"
+  version = "~> 1.2"
   region  = "eu-west-1"
 }
 


### PR DESCRIPTION
PR removes the custom pinning to work around terraform-providers/terraform-provider-aws#6203