### PR TITLE
Implement CWAlarm module for Elasticache alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates Elasticache-Memcached, Elasticache-Redis, or Elasticache-Red
 
 ```
 module "elasticache_memcached" {
- source                     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.5"
+ source                     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.6"
  cluster_name               = "memc-${random_string.r_string.result}"
  elasticache_engine_type    = "memcached14"
  instance_class             = "cache.m4.large"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -31,7 +31,7 @@ module "security_groups" {
 }
 
 module "elasticache_memcached" {
-  source                     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.5"
+  source                     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.6"
   cluster_name               = "memc-${random_string.r_string.result}"
   elasticache_engine_type    = "memcached14"
   instance_class             = "cache.m4.large"
@@ -52,7 +52,7 @@ module "elasticache_memcached" {
 }
 
 module "elasticache_redis_multi_shard" {
-  source                  = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.5"
+  source                  = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.6"
   cluster_name            = "redms-${random_string.r_string.result}"
   elasticache_engine_type = "redis40"
   instance_class          = "cache.m4.large"
@@ -72,7 +72,7 @@ module "elasticache_redis_multi_shard" {
 }
 
 module "elasticache_redis_1" {
-  source                  = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.5"
+  source                  = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.6"
   cluster_name            = "red-${random_string.r_string.result}-1"
   elasticache_engine_type = "redis40"
   instance_class          = "cache.t2.medium"
@@ -92,7 +92,7 @@ module "elasticache_redis_1" {
 }
 
 module "elasticache_redis_2" {
-  source                     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.5"
+  source                     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.6"
   cluster_name               = "red-${random_string.r_string.result}-2"
   elasticache_engine_type    = "redis40"
   instance_class             = "cache.m4.large"

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -116,10 +116,18 @@ module "elasticache_redis_2" {
   }
 }
 
+resource "random_string" "19_char_string" {
+  length  = 19
+  lower   = true
+  upper   = false
+  number  = false
+  special = false
+}
+
 module "elasticache_redis_constructed_cluster_name_20_chars" {
   source                  = "../../module"
-  cluster_name            = "this-is-twenty-chars"
-  cluster_name_version    = "this-is-twenty-chars"
+  cluster_name            = "${random_string.19_char_string.result}a"
+  cluster_name_version    = "${random_string.19_char_string.result}a"
   elasticache_engine_type = "redis40"
   instance_class          = "cache.t2.medium"
   redis_multi_shard       = false
@@ -129,8 +137,8 @@ module "elasticache_redis_constructed_cluster_name_20_chars" {
 
 module "elasticache_redis_constructed_cluster_name_19_chars" {
   source                  = "../../module"
-  cluster_name            = "this-is-only-19-ok"
-  cluster_name_version    = "this-is-only-19-ok"
+  cluster_name            = "${random_string.19_char_string.result}"
+  cluster_name_version    = "${random_string.19_char_string.result}"
   elasticache_engine_type = "redis40"
   instance_class          = "cache.t2.medium"
   redis_multi_shard       = false


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/191
##### Summary of change(s):

- Replaces `aws_cloudwatch_metric_alarm` resources with calls to the `aws-terraform-cloudwatch_alarm` module.
- Updates cluster names in two tests due to naming collisions

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
Yes, due to state file path change.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
No variables updated.  Readme example version updated.
##### Do examples need to be updated based on changes?
Example version pinning updated.
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.