### PR TITLE
Backporting redis 5.0.6 for 0.11.x terraform branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates Elasticache-Memcached, Elasticache-Redis, or Elasticache-Red
 
 ```HCL
 module "elasticache_memcached" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.14"
 
   cluster_name               = "memc-${random_string.name_suffix.result}"
   create_route53_record      = true
@@ -29,52 +29,59 @@ module "elasticache_memcached" {
 ```
 
 Full working references are available at [examples](examples)
-## Other TF Modules Used
-Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:
-	- evictions_alarm
-	- cpu_utilization_alarm
-	- curr_connections_alarm
-	- swap_usage_alarm
+## Other TF Modules Used  
+Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:
+	- evictions\_alarm
+	- cpu\_utilization\_alarm
+	- curr\_connections\_alarm
+	- swap\_usage\_alarm
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| null | n/a |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| additional\_tags | (memcached, redis, redis multi shard) Additional tags to be added to the Elasticache resources. Please see examples directory in this repo for examples. | map | `<map>` | no |
-| at\_rest\_encrypted\_disk | (redis, redis multi shard) Indicates whether to enable encryption at rest. ONLY AVAILABLE FOR REDIS 3.2.6, 4.0.10 AND 5.0.0. `true` or `false`. | string | `"false"` | no |
-| cache\_cluster\_port | (memcached, redis, redis multi shard) The port number on which each of the cache nodes will accept connections. Default for redis is 6379. Default for memcached is 11211 | string | `""` | no |
-| cluster\_name | (memcached, redis, redis multi shard) Name of Cluster. Will also be used to name other provisioned resources. If non empty cluster_name_version is being used, total length of cluster_name plus cluster_name_version should not exceed 19 due to string length constraints | string | n/a | yes |
-| cluster\_name\_version | (memcached, redis, redis multi shard) NOTE: This needs to increment on update with new snapshot. If non empty cluster_name_version is being used, total length of cluster_name plus cluster_name_version should not exceed 19 due to string length constraints | string | `"v00"` | no |
-| cpu\_high\_evaluations | (memcached, redis) The number of minutes CPU usage must remain above the specified threshold to generate an alarm. | string | `"5"` | no |
-| cpu\_high\_threshold | (memcached, redis) The max CPU Usage % before generating an alarm. | string | `"90"` | no |
-| create\_route53\_record | (memcached, redis, redis multi shard) Specifies whether or not to create a route53 CNAME record for the configuration/primary endpoint. internal_zone_id, internal_zone_name, and internal_record_name must be provided if set to true. true or false. | string | `"false"` | no |
-| curr\_connections\_evaluations | (memcached, redis) The number of minutes current connections must remain above the specified threshold to generate an alarm. | string | `"5"` | no |
-| curr\_connections\_threshold | (memcached, redis) The max number of current connections before generating an alarm. NOTE: If this variable is not set, the connections alarm will not be provisioned. | string | `""` | no |
-| elasticache\_engine\_type | (memcached, redis, redis multi shard) The name of the cache engine to be used for this cluster. Valid values are: memcached14, memcached1510, redis28, redis2823, redis2822, redis2821, redis2819, redis286, redis32, redis326, redis3210, redis40, redis50, redis503, redis504, redis505 | string | n/a | yes |
-| environment | (memcached, redis, redis multi shard) Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test | string | `"Development"` | no |
-| evictions\_evaluations | (memcached, redis) The number of minutes Evictions must remain above the specified threshold to generate an alarm. | string | `"5"` | no |
-| evictions\_threshold | (memcached, redis) The max evictions before generating an alarm. NOTE: If this variable is not set, the evictions alarm will not be provisioned. | string | `""` | no |
-| failover\_enabled | (redis) Enable Multi-AZ Failover. Failover is unsupported on the cache.t1.micro instance class. This is hardcoded as true for Redis multi-shard. | string | `"true"` | no |
-| in\_transit\_encryption | (redis, redis multi shard) Indicates whether to enable encryption in transit. Because there is some processing needed to encrypt and decrypt the data at the endpoints, enabling in-transit encryption can have some performance impact.ONLY AVAILABLE FOR REDIS 3.2.6 AND 4.0.10. true or false | string | `"false"` | no |
-| instance\_class | (memcached, redis, redis multi shard) The compute and memory capacity of the nodes within the ElastiCache cluster. Please see https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheNodes.SupportedTypes.html for valid instance types. | string | n/a | yes |
-| internal\_record\_name | (memcached, redis, redis multi shard) Record Name for the new Resource Record in the Internal Hosted Zone | string | `""` | no |
-| internal\_zone\_id | (memcached, redis, redis multi shard) The Route53 Internal Hosted Zone ID | string | `""` | no |
-| internal\_zone\_name | (memcached, redis, redis multi shard) LD for Internal Hosted Zone | string | `""` | no |
-| notification\_topic | (memcached, redis, redis multi shard) SNS Topic ARN to notify if there are any alarms | string | `""` | no |
-| number\_of\_nodes | (memcached, redis) The number of cache nodes within the ElastiCache cluster. This number must be grearter or equal 2 to enable automatic failover. | string | `"1"` | no |
-| number\_of\_read\_replicas\_per\_shard | (redis multi shard) Number of read replicas per shard | string | `"2"` | no |
-| number\_of\_shards | (redis multi shard) Number of shards | string | `"2"` | no |
-| preferred\_maintenance\_window | (memcached, redis, redis multi shard) The weekly time range (in UTC) during which system maintenance can occur. Example: Sun:05:00-Sun:07:00 | string | `"Sun:05:00-Sun:07:00"` | no |
-| redis\_multi\_shard | (edis, redis multi shard) Is this a redis multi-shard instance? true or false | string | `"false"` | no |
-| replication\_group\_description | (redis, redis multi shard) Description of Replication Group | string | `"Elasticache"` | no |
-| security\_group\_list | (memcached, redis, redis multi shard) A list of EC2 security groups to assign to this resource. | list | n/a | yes |
-| snapshot\_arn | (redis, redis multi shard) The S3 ARN of a snapshot to use for cluster creation.  Proper access to the S3 file must be granted prior to building instance.  See https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/backups-seeding-redis.html#backups-seeding-redis-grant-access for details.  This parameter is ignored if a SnapshotName is provided. | string | `""` | no |
-| snapshot\_name | (redis, redis multi shard) The name of a snapshot to use for cluster creation. This property overrides any value assigned to SnapshotArn. Snapshots are unsupported on cache.t1.micro instance class. | string | `""` | no |
-| snapshot\_retention\_limit | (redis, redis multi shard) The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups. Snapshots are unsupported on cache.t1.micro instance class. | string | `"7"` | no |
-| snapshot\_window | (redis, redis multi shard) The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your node group. Snapshots are unsupported on cache.t1.micro instance class. | string | `"03:00-05:00"` | no |
-| subnets | (memcached, redis, redis multi shard) List of subnets for use with this cache cluster | list | n/a | yes |
-| swap\_usage\_evaluations | (memcached) The number of minutes SwapUsage must remain above the specified threshold to generate an alarm | string | `"5"` | no |
-| swap\_usage\_threshold | (memcached) The max SwapUsage before generating an alarm | string | `"52428800"` | no |
+|------|-------------|------|---------|:-----:|
+| additional\_tags | (memcached, redis, redis multi shard) Additional tags to be added to the Elasticache resources. Please see examples directory in this repo for examples. | `map` | `{}` | no |
+| at\_rest\_encrypted\_disk | (redis, redis multi shard) Indicates whether to enable encryption at rest. ONLY AVAILABLE FOR REDIS 3.2.6, 4.0.10 AND 5.0.0. `true` or `false`. | `string` | `false` | no |
+| cache\_cluster\_port | (memcached, redis, redis multi shard) The port number on which each of the cache nodes will accept connections. Default for redis is 6379. Default for memcached is 11211 | `string` | `""` | no |
+| cluster\_name | (memcached, redis, redis multi shard) Name of Cluster. Will also be used to name other provisioned resources. If non empty cluster\_name\_version is being used, total length of cluster\_name plus cluster\_name\_version should not exceed 19 due to string length constraints | `string` | n/a | yes |
+| cluster\_name\_version | (memcached, redis, redis multi shard) NOTE: This needs to increment on update with new snapshot. If non empty cluster\_name\_version is being used, total length of cluster\_name plus cluster\_name\_version should not exceed 19 due to string length constraints | `string` | `"v00"` | no |
+| cpu\_high\_evaluations | (memcached, redis) The number of minutes CPU usage must remain above the specified threshold to generate an alarm. | `string` | `5` | no |
+| cpu\_high\_threshold | (memcached, redis) The max CPU Usage % before generating an alarm. | `string` | `90` | no |
+| create\_route53\_record | (memcached, redis, redis multi shard) Specifies whether or not to create a route53 CNAME record for the configuration/primary endpoint. internal\_zone\_id, internal\_zone\_name, and internal\_record\_name must be provided if set to true. true or false. | `string` | `false` | no |
+| curr\_connections\_evaluations | (memcached, redis) The number of minutes current connections must remain above the specified threshold to generate an alarm. | `string` | `5` | no |
+| curr\_connections\_threshold | (memcached, redis) The max number of current connections before generating an alarm. NOTE: If this variable is not set, the connections alarm will not be provisioned. | `string` | `""` | no |
+| elasticache\_engine\_type | (memcached, redis, redis multi shard) The name of the cache engine to be used for this cluster. Valid values are: memcached14, memcached1510, redis28, redis2823, redis2822, redis2821, redis2819, redis286, redis32, redis326, redis3210, redis40, redis50, redis503, redis504, redis505, redis506 | `string` | n/a | yes |
+| environment | (memcached, redis, redis multi shard) Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test | `string` | `"Development"` | no |
+| evictions\_evaluations | (memcached, redis) The number of minutes Evictions must remain above the specified threshold to generate an alarm. | `string` | `5` | no |
+| evictions\_threshold | (memcached, redis) The max evictions before generating an alarm. NOTE: If this variable is not set, the evictions alarm will not be provisioned. | `string` | `""` | no |
+| failover\_enabled | (redis) Enable Multi-AZ Failover. Failover is unsupported on the cache.t1.micro instance class. This is hardcoded as true for Redis multi-shard. | `string` | `true` | no |
+| in\_transit\_encryption | (redis, redis multi shard) Indicates whether to enable encryption in transit. Because there is some processing needed to encrypt and decrypt the data at the endpoints, enabling in-transit encryption can have some performance impact.ONLY AVAILABLE FOR REDIS 3.2.6 AND 4.0.10. true or false | `string` | `false` | no |
+| instance\_class | (memcached, redis, redis multi shard) The compute and memory capacity of the nodes within the ElastiCache cluster. Please see https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheNodes.SupportedTypes.html for valid instance types. | `string` | n/a | yes |
+| internal\_record\_name | (memcached, redis, redis multi shard) Record Name for the new Resource Record in the Internal Hosted Zone | `string` | `""` | no |
+| internal\_zone\_id | (memcached, redis, redis multi shard) The Route53 Internal Hosted Zone ID | `string` | `""` | no |
+| internal\_zone\_name | (memcached, redis, redis multi shard) LD for Internal Hosted Zone | `string` | `""` | no |
+| notification\_topic | (memcached, redis, redis multi shard) SNS Topic ARN to notify if there are any alarms | `string` | `""` | no |
+| number\_of\_nodes | (memcached, redis) The number of cache nodes within the ElastiCache cluster. This number must be grearter or equal 2 to enable automatic failover. | `string` | `1` | no |
+| number\_of\_read\_replicas\_per\_shard | (redis multi shard) Number of read replicas per shard | `string` | `2` | no |
+| number\_of\_shards | (redis multi shard) Number of shards | `string` | `2` | no |
+| preferred\_maintenance\_window | (memcached, redis, redis multi shard) The weekly time range (in UTC) during which system maintenance can occur. Example: Sun:05:00-Sun:07:00 | `string` | `"Sun:05:00-Sun:07:00"` | no |
+| redis\_multi\_shard | (edis, redis multi shard) Is this a redis multi-shard instance? true or false | `string` | `false` | no |
+| replication\_group\_description | (redis, redis multi shard) Description of Replication Group | `string` | `"Elasticache"` | no |
+| security\_group\_list | (memcached, redis, redis multi shard) A list of EC2 security groups to assign to this resource. | `list` | n/a | yes |
+| snapshot\_arn | (redis, redis multi shard) The S3 ARN of a snapshot to use for cluster creation.  Proper access to the S3 file must be granted prior to building instance.  See https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/backups-seeding-redis.html#backups-seeding-redis-grant-access for details.  This parameter is ignored if a SnapshotName is provided. | `string` | `""` | no |
+| snapshot\_name | (redis, redis multi shard) The name of a snapshot to use for cluster creation. This property overrides any value assigned to SnapshotArn. Snapshots are unsupported on cache.t1.micro instance class. | `string` | `""` | no |
+| snapshot\_retention\_limit | (redis, redis multi shard) The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups. Snapshots are unsupported on cache.t1.micro instance class. | `string` | `7` | no |
+| snapshot\_window | (redis, redis multi shard) The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your node group. Snapshots are unsupported on cache.t1.micro instance class. | `string` | `"03:00-05:00"` | no |
+| subnets | (memcached, redis, redis multi shard) List of subnets for use with this cache cluster | `list` | n/a | yes |
+| swap\_usage\_evaluations | (memcached) The number of minutes SwapUsage must remain above the specified threshold to generate an alarm | `string` | `5` | no |
+| swap\_usage\_threshold | (memcached) The max SwapUsage before generating an alarm | `string` | `52428800` | no |
 
 ## Outputs
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -34,7 +34,7 @@ module "internal_zone" {
 }
 
 module "security_groups" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=v0.0.5"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=v0.0.6"
 
   resource_name = "ElastiCacheTestSG"
   vpc_id        = "${module.vpc.vpc_id}"
@@ -42,7 +42,7 @@ module "security_groups" {
 }
 
 module "elasticache_memcached" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.14"
 
   cluster_name               = "memc-${random_string.r_string.result}"
   elasticache_engine_type    = "memcached14"
@@ -85,7 +85,7 @@ module "elasticache_redis_multi_shard" {
 }
 
 module "elasticache_redis_1" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.14"
 
   cluster_name            = "red-${random_string.r_string.result}-1"
   elasticache_engine_type = "redis50"
@@ -106,7 +106,7 @@ module "elasticache_redis_1" {
 }
 
 module "elasticache_redis_2" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.14"
 
   cluster_name               = "red-${random_string.r_string.result}-2"
   elasticache_engine_type    = "redis50"
@@ -141,7 +141,7 @@ resource "random_string" "19_char_string" {
 }
 
 module "elasticache_redis_constructed_cluster_name_20_chars" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.14"
 
   cluster_name            = "${random_string.19_char_string.result}a"
   cluster_name_version    = "${random_string.19_char_string.result}a"
@@ -153,7 +153,7 @@ module "elasticache_redis_constructed_cluster_name_20_chars" {
 }
 
 module "elasticache_redis_constructed_cluster_name_19_chars" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.13"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticache.git?ref=v0.0.14"
 
   cluster_name            = "${random_string.19_char_string.result}"
   cluster_name_version    = "${random_string.19_char_string.result}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "elasticache_endpoint" {
   description = "Elasticache endpoint address"
-  value       = "${element(coalescelist(aws_elasticache_replication_group.redis_rep_group.*.primary_endpoint_address, aws_elasticache_replication_group.redis_multi_shard_rep_group.*.configuration_endpoint_address, aws_elasticache_cluster.cache_cluster.*.configuration_endpoint, list("novalue")),0)}"
+  value       = "${element(coalescelist(aws_elasticache_replication_group.redis_rep_group.*.primary_endpoint_address, aws_elasticache_replication_group.redis_multi_shard_rep_group.*.configuration_endpoint_address, aws_elasticache_cluster.cache_cluster.*.configuration_endpoint, list("novalue")), 0)}"
 }
 
 output "elasticache_internal_r53_record" {

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -34,7 +34,7 @@ module "internal_zone" {
 }
 
 module "security_groups" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=v0.0.5"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=v0.0.6"
 
   resource_name = "ElastiCacheTestSG"
   vpc_id        = "${module.vpc.vpc_id}"

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "create_route53_record" {
 }
 
 variable "elasticache_engine_type" {
-  description = "(memcached, redis, redis multi shard) The name of the cache engine to be used for this cluster. Valid values are: memcached14, memcached1510, redis28, redis2823, redis2822, redis2821, redis2819, redis286, redis32, redis326, redis3210, redis40, redis50, redis503, redis504, redis505"
+  description = "(memcached, redis, redis multi shard) The name of the cache engine to be used for this cluster. Valid values are: memcached14, memcached1510, redis28, redis2823, redis2822, redis2821, redis2819, redis286, redis32, redis326, redis3210, redis40, redis50, redis503, redis504, redis505, redis506"
   type        = "string"
 }
 


### PR DESCRIPTION
##### Corresponding Issue(s):
 - https://jira.rax.io/browse/MPCSUPENG-1061

##### Summary of change(s):
 - added redis 5.0.6
##### Reason for Change(s):

-people still want 5.0.6 before cuting over to TF 0.12.0

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
no
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
no
##### If input variables or output variables have changed or has been added, have you updated the README?
no
##### Do examples need to be updated based on changes?
no
