### PR TITLE
Support of auth_token for elasticache

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ The following module variables were updated to better meet current Rackspace sty
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | at\_rest\_encrypted\_disk | (redis, redis multi shard) Indicates whether to enable encryption at rest. ONLY AVAILABLE FOR REDIS 3.2.6, 4.0.10 AND 5.0.0. `true` or `false`. | `bool` | `false` | no |
+| authentication\_token | The password used to access a password protected server. Can be specified only if in\_transit\_encryption = true and will be ignored otherwise | `string` | `""` | no |
 | cache\_cluster\_port | (memcached, redis, redis multi shard) The port number on which each of the cache nodes will accept connections. Default for redis is 6379. Default for memcached is 11211 | `string` | `""` | no |
 | cpu\_high\_evaluations | (memcached, redis) The number of minutes CPU usage must remain above the specified threshold to generate an alarm. | `number` | `5` | no |
 | cpu\_high\_threshold | (memcached, redis) The max CPU Usage % before generating an alarm. | `number` | `90` | no |

--- a/main.tf
+++ b/main.tf
@@ -212,6 +212,8 @@ locals {
 
   snapshot_supported = var.instance_class == "cache.t1.micro" ? false : true
 
+  authentication_token = var.in_transit_encryption == true ? var.authentication_token : ""
+
   tags = merge(
     var.tags,
     {
@@ -387,6 +389,7 @@ resource "aws_elasticache_replication_group" "redis_rep_group" {
   count = local.elasticache_name != "memcached" && false == local.redis_multishard ? 1 : 0
 
   at_rest_encryption_enabled    = local.encryption_supported ? var.at_rest_encrypted_disk : false
+  auth_token                    = local.authentication_token
   automatic_failover_enabled    = var.instance_class != "cache.t1.micro" && var.number_of_nodes >= 2 ? var.failover_enabled : false
   engine                        = local.elasticache_name
   engine_version                = local.elasticache_version
@@ -416,6 +419,7 @@ resource "aws_elasticache_replication_group" "redis_multi_shard_rep_group" {
   count = local.redis_multishard && local.elasticache_name != "memcached" ? 1 : 0
 
   at_rest_encryption_enabled    = local.encryption_supported ? var.at_rest_encrypted_disk : false
+  auth_token                    = local.authentication_token
   automatic_failover_enabled    = true
   engine                        = local.elasticache_name
   engine_version                = local.elasticache_version

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "at_rest_encrypted_disk" {
   default     = false
 }
 
+variable "authentication_token" {
+  description = "The password used to access a password protected server. Can be specified only if in_transit_encryption = true and will be ignored otherwise"
+  type        = string
+  default     = ""
+}
+
 variable "cache_cluster_port" {
   description = "(memcached, redis, redis multi shard) The port number on which each of the cache nodes will accept connections. Default for redis is 6379. Default for memcached is 11211"
   type        = string


### PR DESCRIPTION
Can you please label this PR as `hacktoberfest-accepted`?

##### Corresponding Issue(s):
 - No issue exists
##### Summary of change(s):
Support of [auth_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#auth_token) added.

##### Reason for Change(s):
Even if  in_transit_encryption ([transit_encryption_enabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#transit_encryption_enabled)) is specified then authentication is not enabled.

In order to enable password based authentication, we needed to enable it through AWS console. This results in disabling authentication whenever TF script is run. Now authentication is fully managed by TF script

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
NO

##### If input variables or output variables have changed or has been added, have you updated the README?
YES

##### Do examples need to be updated based on changes?
NO

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
