### PR TITLE
Adding Support for auth_token to elasticache 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ The following module variables were updated to better meet current Rackspace sty
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | at\_rest\_encrypted\_disk | (redis, redis multi shard) Indicates whether to enable encryption at rest. ONLY AVAILABLE FOR REDIS 3.2.6, 4.0.10 AND 5.0.0. `true` or `false`. | `bool` | `false` | no |
+| authentication\_token | The password used to access a password protected server. Can be specified only if in\_transit\_encryption = true and will be ignored otherwise | `string` | `""` | no |
 | cache\_cluster\_port | (memcached, redis, redis multi shard) The port number on which each of the cache nodes will accept connections. Default for redis is 6379. Default for memcached is 11211 | `string` | `""` | no |
 | cpu\_high\_evaluations | (memcached, redis) The number of minutes CPU usage must remain above the specified threshold to generate an alarm. | `number` | `5` | no |
 | cpu\_high\_threshold | (memcached, redis) The max CPU Usage % before generating an alarm. | `number` | `90` | no |

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ The following module variables were updated to better meet current Rackspace sty
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+|------|-------------|------|---------|:-----:|
 | at\_rest\_encrypted\_disk | (redis, redis multi shard) Indicates whether to enable encryption at rest. ONLY AVAILABLE FOR REDIS 3.2.6, 4.0.10 AND 5.0.0. `true` or `false`. | `bool` | `false` | no |
-| authentication\_token | The password used to access a password protected server. Can be specified only if in\_transit\_encryption = true and will be ignored otherwise | `string` | `""` | no |
+| authentication\_token | (redis, redis multi shard) The password used to access a password protected server. Can be specified only if `in_transit_encryption = true` and will be ignored otherwise | `string` | `""` | no |
 | cache\_cluster\_port | (memcached, redis, redis multi shard) The port number on which each of the cache nodes will accept connections. Default for redis is 6379. Default for memcached is 11211 | `string` | `""` | no |
 | cpu\_high\_evaluations | (memcached, redis) The number of minutes CPU usage must remain above the specified threshold to generate an alarm. | `number` | `5` | no |
 | cpu\_high\_threshold | (memcached, redis) The max CPU Usage % before generating an alarm. | `number` | `90` | no |
@@ -77,7 +77,7 @@ The following module variables were updated to better meet current Rackspace sty
 | evictions\_evaluations | (memcached, redis) The number of minutes Evictions must remain above the specified threshold to generate an alarm. | `number` | `5` | no |
 | evictions\_threshold | (memcached, redis) The max evictions before generating an alarm. NOTE: If this variable is not set, the evictions alarm will not be provisioned. | `string` | `""` | no |
 | failover\_enabled | (redis) Enable Multi-AZ Failover. Failover is unsupported on the cache.t1.micro instance class. This is hardcoded as true for Redis multi-shard. | `bool` | `true` | no |
-| in\_transit\_encryption | (redis, redis multi shard) Indicates whether to enable encryption in transit. Because there is some processing needed to encrypt and decrypt the data at the endpoints, enabling in-transit encryption can have some performance impact.ONLY AVAILABLE FOR REDIS 3.2.6 AND 4.0.10. true or false | `bool` | `false` | no |
+| in\_transit\_encryption | (redis, redis multi shard) Indicates whether to enable encryption in transit. Because there is some processing needed to encrypt and decrypt the data at the endpoints, enabling in-transit encryption can have some performance impact.ONLY AVAILABLE FOR REDIS 3.2.6, 4.0.10 and later. true or false | `bool` | `false` | no |
 | instance\_class | (memcached, redis, redis multi shard) The compute and memory capacity of the nodes within the ElastiCache cluster. Please see https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheNodes.SupportedTypes.html for valid instance types. | `string` | n/a | yes |
 | internal\_record\_name | (memcached, redis, redis multi shard) Record Name for the new Resource Record in the Internal Hosted Zone | `string` | `""` | no |
 | internal\_zone\_id | (memcached, redis, redis multi shard) The Route53 Internal Hosted Zone ID | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -212,7 +212,7 @@ locals {
 
   snapshot_supported = var.instance_class == "cache.t1.micro" ? false : true
 
-  authentication_token = var.in_transit_encryption == true ? var.authentication_token : ""
+  authentication_token = var.in_transit_encryption == true ? var.authentication_token : null
 
   tags = merge(
     var.tags,

--- a/main.tf
+++ b/main.tf
@@ -212,6 +212,8 @@ locals {
 
   snapshot_supported = var.instance_class == "cache.t1.micro" ? false : true
 
+  authentication_token = var.in_transit_encryption == true ? var.authentication_token : ""
+
   tags = merge(
     var.tags,
     {
@@ -387,6 +389,7 @@ resource "aws_elasticache_replication_group" "redis_rep_group" {
   count = local.elasticache_name != "memcached" && false == local.redis_multishard ? 1 : 0
 
   at_rest_encryption_enabled    = local.encryption_supported ? var.at_rest_encrypted_disk : false
+  auth_token                    = local.authentication_token
   automatic_failover_enabled    = var.instance_class != "cache.t1.micro" && var.number_of_nodes >= 2 ? var.failover_enabled : false
   engine                        = local.elasticache_name
   engine_version                = local.elasticache_version
@@ -416,6 +419,7 @@ resource "aws_elasticache_replication_group" "redis_multi_shard_rep_group" {
   count = local.redis_multishard && local.elasticache_name != "memcached" ? 1 : 0
 
   at_rest_encryption_enabled    = local.encryption_supported ? var.at_rest_encrypted_disk : false
+  auth_token                    = local.authentication_token
   automatic_failover_enabled    = true
   engine                        = local.elasticache_name
   engine_version                = local.elasticache_version

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -169,3 +169,16 @@ module "elasticache_redis_constructed_cluster_name_19_chars" {
   subnets                 = module.vpc.private_subnets
 }
 
+
+module "elasticache_redis_secured" {
+  source = "../../module"
+
+  authentication_token    = "MyV3ryS3cur3T0k3n!"
+  elasticache_engine_type = "redis506"
+  in_transit_encryption   = true
+  instance_class          = "cache.m4.large"
+  name                    = "redsec-${random_string.r_string.result}"
+  redis_multi_shard       = true
+  security_groups         = [module.security_groups.elastic_cache_redis_security_group_id]
+  subnets                 = module.vpc.private_subnets
+}

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "at_rest_encrypted_disk" {
 }
 
 variable "authentication_token" {
-  description = "The password used to access a password protected server. Can be specified only if in_transit_encryption = true and will be ignored otherwise"
+  description = "(redis, redis multi shard) The password used to access a password protected server. Can be specified only if `in_transit_encryption = true` and will be ignored otherwise"
   type        = string
   default     = ""
 }
@@ -76,7 +76,7 @@ variable "failover_enabled" {
 }
 
 variable "in_transit_encryption" {
-  description = "(redis, redis multi shard) Indicates whether to enable encryption in transit. Because there is some processing needed to encrypt and decrypt the data at the endpoints, enabling in-transit encryption can have some performance impact.ONLY AVAILABLE FOR REDIS 3.2.6 AND 4.0.10. true or false"
+  description = "(redis, redis multi shard) Indicates whether to enable encryption in transit. Because there is some processing needed to encrypt and decrypt the data at the endpoints, enabling in-transit encryption can have some performance impact.ONLY AVAILABLE FOR REDIS 3.2.6, 4.0.10 and later. true or false"
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "at_rest_encrypted_disk" {
   default     = false
 }
 
+variable "authentication_token" {
+  description = "The password used to access a password protected server. Can be specified only if in_transit_encryption = true and will be ignored otherwise"
+  type        = string
+  default     = ""
+}
+
 variable "cache_cluster_port" {
   description = "(memcached, redis, redis multi shard) The port number on which each of the cache nodes will accept connections. Default for redis is 6379. Default for memcached is 11211"
   type        = string


### PR DESCRIPTION
##### Corresponding Issue(s):
- https://jira.rax.io/browse/MPCSUPENG-1632
- See also: https://github.com/rackspace-infrastructure-automation/aws-terraform-elasticache/pull/30
- Thanks  to @katsadim  for the code contribution

##### Summary of change(s):
- added authentication_token variable for redis and redis_multi
- added an accompanying test
##### Reason for Change(s):
- will allow for more secure deployments for application  engines

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
no
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
yes
##### If input variables or output variables have changed or has been added, have you updated the README?
yes
##### Do examples need to be updated based on changes?
not necessarily


